### PR TITLE
Add build dependencies for Fedora and fix the instruction of Cross toolchain

### DIFF
--- a/SG2042/HowTo/How to build SG2042 bsp.rst
+++ b/SG2042/HowTo/How to build SG2042 bsp.rst
@@ -40,11 +40,17 @@ To build uroot, you need to install **go 1.17**, refer to https://tecadmin.net/h
       $ git clone https://github.com/sophgo/bootloader-riscv.git
       $ git clone https://github.com/sophgo/linux-sophgo.git
 
-- Install cross-compilation toolchains
+- Build Cross toolchain for bsp
 
-  Create the directory called ``gcc-riscv`` in the same level as
-  ``bootloader-riscv`` and ``linux-sophgo``, and install the
-  cross-compilation toolchains to the directory.
+  Enter the bsp directory which is the same level as ``bootloader-riscv`` and
+  ``linux-sophgo``, and build Cross toolchain by the following command:
+  .. highlights::
+
+   .. code:: sh
+      $ CHIP=mango
+      $ source bootloader-riscv/scripts/envsetup.sh
+      $ build_rv_gcc
+
   You will get the following folders:
 
 .. highlights::

--- a/SG2042/HowTo/How to build SG2042 bsp.rst
+++ b/SG2042/HowTo/How to build SG2042 bsp.rst
@@ -5,13 +5,21 @@ How to build bsp
 1. Install dependencies
 =======================
 
+-   on Fedora
 .. highlights::
 
    .. code:: sh
+      $ sudo dnf install autoconf automake curl python3 libmpc-devel mpfr-devel gmp-devel gawk bison flex texinfo gperf libtool patchutils bc openssl dkms libudev-devel golang-bin zlib-devel  qemu-user-binfmt  qemu-user-static ncurses-devel expat-devel elfutils-libelf-devel pciutils-devel openssl-devel binutils-devel qemu-system-riscv-core
+      $ sudo dnf groupinstall "Development Tools" "C Development Tools and Libraries"
 
+-   on Ubuntu
+.. highlights::
+
+   .. code:: sh
       $ sudo apt-get install autoconf automake autotools-dev curl python3 libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev libncurses-dev openssl libiberty-dev libssl-dev dkms libelf-dev libudev-dev libpci-dev golang-go qemu-user-binfmt qemu-system-misc  qemu-user-static
 
 To build uroot, you need to install **go 1.17**, refer to https://tecadmin.net/how-to-install-go-on-ubuntu-20-04/. You can use the following reference to check the go version.
+
 
 .. highlights::
 


### PR DESCRIPTION
Adding Fedora distro support in "Install dependencies"
Get Cross toolchain by building natively instead of downloading.

Signed-off-by: Wei Fu <wefu@redhat.com>
