### PR TITLE
SG2042: fix issue to pass build on Ubuntu

### DIFF
--- a/SG2042/TRM/source/conf.py
+++ b/SG2042/TRM/source/conf.py
@@ -25,3 +25,6 @@ exclude_patterns = []
 
 html_theme = 'alabaster'
 html_static_path = ['_static']
+
+# By default, Sphinx expects the master doc to be contents. Set master doc to index instead.
+master_doc = 'index'


### PR DESCRIPTION
Run `make latexpdf` and got error:
Sphinx error:
master file /home/u/ws/sg2042/sophgo-doc/SG2042/TRM/source/contents.rst not found
make: *** [Makefile:20: latexpdf] Error 1

By default, Sphinx expects the master doc to be contents. But we are using index.