### PR TITLE
sg200x:trm: update pwm part

### DIFF
--- a/SG200X/TRM/contents/cn/peripherals/pwm.rst
+++ b/SG200X/TRM/contents/cn/peripherals/pwm.rst
@@ -4,12 +4,22 @@ PWM
 概述
 ~~~~
 
-芯片提供 1 组 4 路独立的 PWM 信号输出。
+芯片提供 4 个 PWM 控制器 PWM0、PWM1、PWM2 和 PWM3。
+
+每个控制器提供 4 路独立的 PWM 信号输出。它们是：
+
+- PWM0 包括 PWM[0], PWM[1], PWM[2], PWM[3]。
+
+- PWM1 包括 PWM[4], PWM[5], PWM[6], PWM[7]。
+
+- PWM2 包括 PWM[8], PWM[9], PWM[10], PWM[11]。
+
+- PWM3 包括 PWM[12], PWM[13], PWM[14], PWM[15]。
 
 特点
 ~~~~
 
-PWM 的时钟来源为 100MHz 和 148.5MHz 二选一，默认为 100MHz。4 路 PWM 皆可独立操作：
+PWM 的时钟来源为 100MHz 和 148.5MHz 二选一，默认为 100MHz。
 
 - 内部有 30-bit 计数器, 输出周期和高/低电平拍数皆可配置。
 
@@ -22,15 +32,15 @@ PWM 的时钟来源为 100MHz 和 148.5MHz 二选一，默认为 100MHz。4 路 
 工作方式
 ~~~~~~~~
 
-PWM 基本配置流程如下 (以 PWM0 为例):
+PWM 基本配置流程如下 (以 PWM[0] 为例):
 
 1. 基于选定的时钟源，通过计算得到需输出的方波周期和低电平拍数。
 
 2. 将对应值写入寄存器 HLPERIOD0、PERIOD0。
 
-3. 若要操作在连续输出模式，配置 PWMMODE 为 0, 将 PWMSTART[0] 设 1 后, PWM0 开始输出，直到 PWMSTART[0] 设 0 后结束输出。
+3. 若要操作在连续输出模式，配置 PWMMODE 为 0, 将 PWMSTART[0] 设 1 后, PWM[0] 开始输出，直到 PWMSTART[0] 设 0 后结束输出。
 
-4. 若要操作在固定脉冲个数输出模式，配置 PWMMODE 为 1, 需输出的方波数目写入寄存器 PCOUNT0。将 PWMSTART[0] 设 1 后, PWM0 开始输出，达到设定的方波数后自动结束，状态寄存器 PWMDONE 由 0 转 1。
+4. 若要操作在固定脉冲个数输出模式，配置 PWMMODE 为 1, 需输出的方波数目写入寄存器 PCOUNT0。将 PWMSTART[0] 设 1 后, PWM[0] 开始输出，达到设定的方波数后自动结束，状态寄存器 PWMDONE 由 0 转 1。
 
 .. _diagram_pwm_continuous_mode:
 .. figure:: ../../../../media/image133.png
@@ -48,7 +58,7 @@ PWM 基本配置流程如下 (以 PWM0 为例):
 
 1. 使用默认 100MHz 时钟源，周期数 (PERIOD0) 配置为 100MHz / 1MHz = 100, 低电平数 (HLPERIOD0) 配置为 100 x 75% = 75。脉冲数 (PCOUNT0) 配置为 16。
 
-2. PWMSTART [0] 写 1 后开始输出波形。
+2. PWMSTART[0] 写 1 后开始输出波形。
 
 3. 读取寄存器 PWMDONE[0] 直到值为 1, 表示输出完成。
 
@@ -60,9 +70,9 @@ PWM 基本配置流程如下 (以 PWM0 为例):
 
 1. 配置 HLPERIOD0/PERIOD0, HLPERIOD1/PERIOD1, HLPERIOD2/PERIOD2, HLPERIOD3/PERIOD3为相同值。
 
-2. 依4路方波波形需要错开的 phase 差，配置适当值到寄存器 SHIFTCOUNT0, SHIFTCOUNT1, SHIFTCOUNT2, SHIFTCOUNT3。
+2. 依 4 路方波波形需要错开的 phase 差，配置适当值到寄存器 SHIFTCOUNT0, SHIFTCOUNT1, SHIFTCOUNT2, SHIFTCOUNT3。
 
-3. 配置 PWMSTART[3:0]为4'hF, 并将 SHIFTSTART 设 1, 4 路的计数器同时开始计数，并在计数器值等于 SHIFTCOUNTn 时输出第 n 路的 PWM 波形。
+3. 配置 PWMSTART[3:0] 为 4'hF, 并将 SHIFTSTART 设 1, 4 路的计数器同时开始计数，并在计数器值等于 SHIFTCOUNTn 时输出第 n 路的 PWM 波形。
 
 .. _diagram_pwm_continuous_shift_mode:
 .. figure:: ../../../../media/image135.png
@@ -83,11 +93,13 @@ PWM 基本配置流程如下 (以 PWM0 为例):
 PWM 寄存器概览
 ~~~~~~~~~~~~~~
 
-PWM 寄存器概览如表格 :ref:`table_pwm_register_overview` 所示。
+PWM 寄存器概览如表格 :ref:`table_pwm_register_overview` 所示，这里以 PWM0 控制器为例，其他 3 个控制器类似。
 
 .. include:: ./pwm_registers_overview.table.rst
 
 PWM 寄存器描述
 ~~~~~~~~~~~~~~
+
+以 PWM0 控制器为例，其他 3 个控制器类似。
 
 .. include:: ./pwn_registers_description.table.rst

--- a/SG200X/TRM/contents/cn/peripherals/pwm_registers_overview.table.rst
+++ b/SG200X/TRM/contents/cn/peripherals/pwm_registers_overview.table.rst
@@ -6,21 +6,21 @@
 	| Name                 | Address | Description                        |
 	|                      | Offset  |                                    |
 	+======================+=========+====================================+
-	| HLPERIOD0            | 0x000   | PWM0 low -level shooting number    |
+	| HLPERIOD0            | 0x000   | PWM[0] low -level shooting number  |
 	+----------------------+---------+------------------------------------+
-	| PERIOD0              | 0x004   | PWM0 square wave cycle shooting    |
+	| PERIOD0              | 0x004   | PWM[0] square wave cycle shooting  |
 	+----------------------+---------+------------------------------------+
-	| HLPERIOD1            | 0x008   | PWM1 low -level shooting number    |
+	| HLPERIOD1            | 0x008   | PWM[1] low -level shooting number  |
 	+----------------------+---------+------------------------------------+
-	| PERIOD1              | 0x00c   | PWM1 Fang wave cycle shooting      |
+	| PERIOD1              | 0x00c   | PWM[1] square wave cycle shooting  |
 	+----------------------+---------+------------------------------------+
-	| HLPERIOD2            | 0x010   | PWM2 low -level shooting number    |
+	| HLPERIOD2            | 0x010   | PWM[2] low -level shooting number  |
 	+----------------------+---------+------------------------------------+
-	| PERIOD2              | 0x014   | PWM2 square wave cycle shooting    |
+	| PERIOD2              | 0x014   | PWM[2] square wave cycle shooting  |
 	+----------------------+---------+------------------------------------+
-	| HLPERIOD3            | 0x018   | PWM3 low -level shooting number    |
+	| HLPERIOD3            | 0x018   | PWM[3] low -level shooting number  |
 	+----------------------+---------+------------------------------------+
-	| PERIOD3              | 0x01c   | PWM3 square wave cycle shooting    |
+	| PERIOD3              | 0x01c   | PWM[3] square wave cycle shooting  |
 	+----------------------+---------+------------------------------------+
 	| POLARITY             | 0x040   | PWM mode settings                  |
 	+----------------------+---------+------------------------------------+
@@ -30,32 +30,32 @@
 	+----------------------+---------+------------------------------------+
 	| PWMUPDATE            | 0x04c   | Dynamic loading PWM cycle parameter|
 	+----------------------+---------+------------------------------------+
-	| PCOUNT0              | 0x050   | Set pwm0 pulse number              |
+	| PCOUNT0              | 0x050   | Set PWM[0] pulse number            |
 	+----------------------+---------+------------------------------------+
-	| PCOUNT1              | 0x054   | Set PWM1 pulse number              |
+	| PCOUNT1              | 0x054   | Set PWM[1] pulse number            |
 	+----------------------+---------+------------------------------------+
-	| PCOUNT2              | 0x058   | Set PWM2 pulse number              |
+	| PCOUNT2              | 0x058   | Set PWM[2] pulse number            |
 	+----------------------+---------+------------------------------------+
-	| PCOUNT3              | 0x05c   | Set PWM3 pulse number              |
+	| PCOUNT3              | 0x05c   | Set PWM[3] pulse number            |
 	+----------------------+---------+------------------------------------+
-	| PULSECOUNT0          | 0x060   | PWM0 output pulse meter status     |
+	| PULSECOUNT0          | 0x060   | PWM[0] output pulse meter status   |
 	+----------------------+---------+------------------------------------+
-	| PULSECOUNT1          | 0x064   | PWM1 has output pulse meter status |
+	| PULSECOUNT1          | 0x064   | PWM[1] output pulse meter status   |
 	+----------------------+---------+------------------------------------+
-	| PULSECOUNT2          | 0x068   | PWM2 has output pulse meter status |
+	| PULSECOUNT2          | 0x068   | PWM[2] output pulse meter status   |
 	+----------------------+---------+------------------------------------+
-	| PULSECOUNT3          | 0x06c   | PWM3 has output pulse meter status |
+	| PULSECOUNT3          | 0x06c   | PWM[3] output pulse meter status   |
 	+----------------------+---------+------------------------------------+
-	| SHIFTCOUNT0          | 0x080   | Synchronous mode PWM0              |
+	| SHIFTCOUNT0          | 0x080   | Synchronous mode PWM[0]            |
 	|                      |         | initial difference                 |
 	+----------------------+---------+------------------------------------+
-	| SHIFTCOUNT1          | 0x084   | Synchronous mode PWM1              |
+	| SHIFTCOUNT1          | 0x084   | Synchronous mode PWM[1]            |
 	|                      |         | initial difference                 |
 	+----------------------+---------+------------------------------------+
-	| SHIFTCOUNT2          | 0x088   | Synchronous mode PWM2              |
+	| SHIFTCOUNT2          | 0x088   | Synchronous mode PWM[2]            |
 	|                      |         | initial difference                 |
 	+----------------------+---------+------------------------------------+
-	| SHIFTCOUNT3          | 0x08c   | Synchronous mode PWM3              |
+	| SHIFTCOUNT3          | 0x08c   | Synchronous mode PWM[3]            |
 	|                      |         | initial difference                 |
 	+----------------------+---------+------------------------------------+
 	| SHIFTSTART           | 0x090   | PWM synchronization mode enable    |

--- a/SG200X/TRM/contents/cn/peripherals/pwn_registers_description.table.rst
+++ b/SG200X/TRM/contents/cn/peripherals/pwn_registers_description.table.rst
@@ -8,7 +8,7 @@ HLPERIOD0
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 29:0 | HLPERIOD0            | R/W   | PWM0 Number of low     | 0x1  |
+	| 29:0 | HLPERIOD0            | R/W   | PWM[0] Number of low   | 0x1  |
 	|      |                      |       | level taps (in clk_pwm)|      |
 	|      |                      |       |                        |      |
 	|      |                      |       | When POLARITY[0] is 0, |      |
@@ -30,8 +30,9 @@ PERIOD0
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 29:0 | PERIOD0              | R/W   | PWM0 Square wave period| 0x2  |
-	|      |                      |       | beats (in clk_pwm)     |      |
+	| 29:0 | PERIOD0              | R/W   | PWM[0] Square wave     | 0x2  |
+	|      |                      |       | period beats           |      |
+	|      |                      |       | (in clk_pwm)           |      |
 	|      |                      |       |                        |      |
 	|      |                      |       | Note The PERIOD value  |      |
 	|      |                      |       | must be greater than   |      |
@@ -48,7 +49,7 @@ HLPERIOD1
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 29:0 | HLPERIOD1            | R/W   | PWM1 Number of low     | 0x1  |
+	| 29:0 | HLPERIOD1            | R/W   | PWM[1] Number of low   | 0x1  |
 	|      |                      |       | level taps (in clk_pwm)|      |
 	|      |                      |       |                        |      |
 	|      |                      |       | When POLARITY[1] is 0, |      |
@@ -70,8 +71,9 @@ PERIOD1
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 29:0 | PERIOD1              | R/W   | PWM1 Square wave period| 0x2  |
-	|      |                      |       | beats (in clk_pwm)     |      |
+	| 29:0 | PERIOD1              | R/W   | PWM[1] Square wave     | 0x2  |
+	|      |                      |       | period beats           |      |
+	|      |                      |       | (in clk_pwm)           |      |
 	|      |                      |       |                        |      |
 	|      |                      |       | Note The PERIOD value  |      |
 	|      |                      |       | must be greater than   |      |
@@ -88,7 +90,7 @@ HLPERIOD2
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 29:0 | HLPERIOD2            | R/W   | PWM2 Number of low     | 0x1  |
+	| 29:0 | HLPERIOD2            | R/W   | PWM[2] Number of low   | 0x1  |
 	|      |                      |       | level taps (in clk_pwm)|      |
 	|      |                      |       |                        |      |
 	|      |                      |       | When POLARITY[2] is 0, |      |
@@ -110,8 +112,9 @@ PERIOD2
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 29:0 | PERIOD2              | R/W   | PWM2 Square wave period| 0x2  |
-	|      |                      |       | beats (in clk_pwm)     |      |
+	| 29:0 | PERIOD2              | R/W   | PWM[2] Square wave     | 0x2  |
+	|      |                      |       | period beats           |      |
+	|      |                      |       | (in clk_pwm)           |      |
 	|      |                      |       |                        |      |
 	|      |                      |       | Note The PERIOD value  |      |
 	|      |                      |       | must be greater than   |      |
@@ -128,7 +131,7 @@ HLPERIOD3
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 29:0 | HLPERIOD3            | R/W   | PWM3 Number of low     | 0x1  |
+	| 29:0 | HLPERIOD3            | R/W   | PWM[3] Number of low   | 0x1  |
 	|      |                      |       | level taps (in clk_pwm)|      |
 	|      |                      |       |                        |      |
 	|      |                      |       | When POLARITY[3] is 0, |      |
@@ -150,8 +153,9 @@ PERIOD3
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 29:0 | PERIOD3              | R/W   | PWM3 Square wave period| 0x2  |
-	|      |                      |       | beats (in clk_pwm)     |      |
+	| 29:0 | PERIOD3              | R/W   | PWM[3] Square wave     | 0x2  |
+	|      |                      |       | period beats           |      |
+	|      |                      |       | (in clk_pwm)           |      |
 	|      |                      |       |                        |      |
 	|      |                      |       | Note The PERIOD value  |      |
 	|      |                      |       | must be greater than   |      |
@@ -168,25 +172,27 @@ POLARITY
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 3:0  | POLARITY             | R/W   | PWM0~3 signal polarity | 0x0  |
+	| 3:0  | POLARITY             | R/W   | PWM[0]~[3] signal      | 0x0  |
+	|      |                      |       | polarity               |      |
 	|      |                      |       |                        |      |
-	|      |                      |       | [n] = 0: PWMn          |      |
+	|      |                      |       | [n] = 0: PWM[n]        |      |
 	|      |                      |       | Default is low         |      |
 	|      |                      |       | level output           |      |
 	|      |                      |       |                        |      |
-	|      |                      |       | [n] = 1: PWMn          |      |
+	|      |                      |       | [n] = 1: PWM[n]        |      |
 	|      |                      |       | Default is high        |      |
 	|      |                      |       | level output           |      |
 	+------+----------------------+-------+------------------------+------+
 	| 7:4  | Reserved             |       |                        |      |
 	+------+----------------------+-------+------------------------+------+
-	| 11:8 | PWMMODE              | R/W   | PWM0~3 operating mode  | 0x0  |
+	| 11:8 | PWMMODE              | R/W   | PWM[0]~[3] operating   | 0x0  |
+	|      |                      |       | mode                   |      |
 	|      |                      |       |                        |      |
-	|      |                      |       | [n+8] = 0: PWMn        |      |
+	|      |                      |       | [n+8] = 0: PWM[n]      |      |
 	|      |                      |       | Operation in Continuous|      |
 	|      |                      |       | Out Mode               |      |
 	|      |                      |       |                        |      |
-	|      |                      |       | [n+8] = 1: PWMn        |      |
+	|      |                      |       | [n+8] = 1: PWM[n]      |      |
 	|      |                      |       | Operation in fixed     |      |
 	|      |                      |       | output mode            |      |
 	+------+----------------------+-------+------------------------+------+
@@ -195,11 +201,11 @@ POLARITY
 	| 16   | SHIFTMODE            | R/W   | Enable PWM synchronous | 0x0  |
 	|      |                      |       | phase output mode      |      |
 	|      |                      |       |                        |      |
-	|      |                      |       | 0 = PWM0~3             |      |
+	|      |                      |       | 0 = PWM[0]~[3]         |      |
 	|      |                      |       | operate in general mode|      |
 	|      |                      |       |                        |      |
-	|      |                      |       | 1 = PWM0~3 operate in  |      |
-	|      |                      |       | 4-way synchronised     |      |
+	|      |                      |       | 1 = PWM[0]~[3] operate |      |
+	|      |                      |       | in 4-way synchronised  |      |
 	|      |                      |       | output mode            |      |
 	+------+----------------------+-------+------------------------+------+
 	| 19:17| Reserved             |       |                        |      |
@@ -228,33 +234,35 @@ PWMSTART
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 3:0  | PWMSTART             | R/W   | EnablePWM0~3           | 0x0  |
+	| 3:0  | PWMSTART             | R/W   | Enable PWM[0]~[3]      | 0x0  |
 	|      |                      |       |                        |      |
-	|      |                      |       | [n] = 0: Stop PWMn     |      |
+	|      |                      |       | [n] = 0: Stop PWM[n]   |      |
 	|      |                      |       |                        |      |
-	|      |                      |       | [n] = 1: Output PWMn   |      |
+	|      |                      |       | [n] = 1: Output PWM[n] |      |
 	|      |                      |       |                        |      |
-	|      |                      |       | When PWMMODE is set to |      |
-	|      |                      |       | 0, write bit n to 0 and|      |
+	|      |                      |       | When PWMMODE is 0,     |      |
+	|      |                      |       | write bit n to 0 and   |      |
 	|      |                      |       | then write 1 to start  |      |
-	|      |                      |       | PWMn output, until bit |      |
-	|      |                      |       | n is written to 0 to   |      |
-	|      |                      |       | stop output. When      |      |
-	|      |                      |       | PWMMODE is set to 1,   |      |
+	|      |                      |       | PWM[n] output, until   |      |
+	|      |                      |       | bit n is written to 0  |      |
+	|      |                      |       | to stop output.        |      |
+	|      |                      |       |                        |      |
+	|      |                      |       | When PWMMODE is 1,     |      |
 	|      |                      |       | write bit n to 1 to    |      |
-	|      |                      |       | start PWMn output, and |      |
-	|      |                      |       | stop output            |      |
+	|      |                      |       | start PWM[n] output,   |      |
+	|      |                      |       | and stop output        |      |
 	|      |                      |       | automatically when the |      |
 	|      |                      |       | number of pulses output|      |
 	|      |                      |       | output equals to the   |      |
 	|      |                      |       | value of PCOUNTn.      |      |
+	|      |                      |       |                        |      |
 	|      |                      |       | When SHIFTMODE is set  |      |
 	|      |                      |       | to 1, PWMSTART[3:0]    |      |
-	|      |                      |       | will be PWM0           |      |
-	|      |                      |       | ~PWMSTART[3:0] will be |      |
-	|      |                      |       | PWM0~ and will be      |      |
+	|      |                      |       | will be output enable  |      |
+	|      |                      |       | for PWM[0]~[3]. Start  |      |
+	|      |                      |       | of PWM will be         |      |
 	|      |                      |       | controlled by          |      |
-	|      |                      |       | SHIFTSTART             |      |
+	|      |                      |       | SHIFTSTART.            |      |
 	+------+----------------------+-------+------------------------+------+
 	| 31:4 | Reserved             |       |                        |      |
 	+------+----------------------+-------+------------------------+------+
@@ -269,7 +277,8 @@ PWMDONE
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 3:0  | PWMDONE              | RO    | PWM0~3 End output state|      |
+	| 3:0  | PWMDONE              | RO    | PWM[0]~[3] End output  |      |
+	|      |                      |       | state                  |      |
 	|      |                      |       |                        |      |
 	|      |                      |       | [n] = 1: PWMn          |      |
 	|      |                      |       | Closed Output          |      |
@@ -323,7 +332,7 @@ PCOUNT0
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 23:0 | PCOUNT0              | R/W   | Number of PWM0 pulses  | 0x1  |
+	| 23:0 | PCOUNT0              | R/W   | Number of PWM[0] pulses| 0x1  |
 	|      |                      |       | (set value must be     |      |
 	|      |                      |       | greater than 0)        |      |
 	|      |                      |       |                        |      |
@@ -344,7 +353,7 @@ PCOUNT1
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 23:0 | PCOUNT1              | R/W   | Number of PWM1 pulses  | 0x1  |
+	| 23:0 | PCOUNT1              | R/W   | Number of PWM[1] pulses| 0x1  |
 	|      |                      |       | (set value must be     |      |
 	|      |                      |       | greater than 0)        |      |
 	|      |                      |       |                        |      |
@@ -364,7 +373,7 @@ PCOUNT2
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 23:0 | PCOUNT2              | R/W   | Number of PWM2 pulses  | 0x1  |
+	| 23:0 | PCOUNT2              | R/W   | Number of PWM[2] pulses| 0x1  |
 	|      |                      |       | (set value must be     |      |
 	|      |                      |       | greater than 0)        |      |
 	|      |                      |       |                        |      |
@@ -384,7 +393,7 @@ PCOUNT3
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 23:0 | PCOUNT3              | R/W   | Number of PWM3 pulses  | 0x1  |
+	| 23:0 | PCOUNT3              | R/W   | Number of PWM[3] pulses| 0x1  |
 	|      |                      |       | (set value must be     |      |
 	|      |                      |       | greater than 0)        |      |
 	|      |                      |       |                        |      |
@@ -404,7 +413,7 @@ PULSECOUNT0
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 23:0 | PULSECOUNT0          | RO    | PWM0                   |      |
+	| 23:0 | PULSECOUNT0          | RO    | PWM[0]                 |      |
 	|      |                      |       | Number of Output       |      |
 	|      |                      |       | Pulses Status          |      |
 	+------+----------------------+-------+------------------------+------+
@@ -421,7 +430,7 @@ PULSECOUNT1
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 23:0 | PULSECOUNT1          | RO    | PWM1                   |      |
+	| 23:0 | PULSECOUNT1          | RO    | PWM[1]                 |      |
 	|      |                      |       | Number of Output       |      |
 	|      |                      |       | Pulses Status          |      |
 	+------+----------------------+-------+------------------------+------+
@@ -438,7 +447,7 @@ PULSECOUNT2
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 23:0 | PULSECOUNT2          | RO    | PWM2                   |      |
+	| 23:0 | PULSECOUNT2          | RO    | PWM[2]                 |      |
 	|      |                      |       | Number of Output       |      |
 	|      |                      |       | Pulses Status          |      |
 	+------+----------------------+-------+------------------------+------+
@@ -455,7 +464,7 @@ PULSECOUNT3
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 23:0 | PULSECOUNT3          | RO    | PWM3                   |      |
+	| 23:0 | PULSECOUNT3          | RO    | PWM[3]                 |      |
 	|      |                      |       | Number of Output       |      |
 	|      |                      |       | Pulses Status          |      |
 	+------+----------------------+-------+------------------------+------+
@@ -472,7 +481,7 @@ SHIFTCOUNT0
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 23:0 | SHIFTCOUNT0          | R/W   | PWM0                   | 0x0  |
+	| 23:0 | SHIFTCOUNT0          | R/W   | PWM[0]                 | 0x0  |
 	|      |                      |       | Phase difference of    |      |
 	|      |                      |       | the first pulse output |      |
 	|      |                      |       | (in clk_pwm)           |      |
@@ -493,7 +502,7 @@ SHIFTCOUNT1
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 23:0 | SHIFTCOUNT1          | R/W   | PWM1                   | 0x0  |
+	| 23:0 | SHIFTCOUNT1          | R/W   | PWM[1]                 | 0x0  |
 	|      |                      |       | Phase difference of    |      |
 	|      |                      |       | the first pulse output |      |
 	|      |                      |       | (in clk_pwm)           |      |
@@ -514,7 +523,7 @@ SHIFTCOUNT2
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 23:0 | SHIFTCOUNT2          | R/W   | PWM2                   | 0x0  |
+	| 23:0 | SHIFTCOUNT2          | R/W   | PWM[2]                 | 0x0  |
 	|      |                      |       | Phase difference of    |      |
 	|      |                      |       | the first pulse output |      |
 	|      |                      |       | (in clk_pwm)           |      |
@@ -535,7 +544,7 @@ SHIFTCOUNT3
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 23:0 | SHIFTCOUNT3          | R/W   | PWM3                   | 0x0  |
+	| 23:0 | SHIFTCOUNT3          | R/W   | PWM[3]                 | 0x0  |
 	|      |                      |       | Phase difference of    |      |
 	|      |                      |       | the first pulse output |      |
 	|      |                      |       | (in clk_pwm)           |      |
@@ -561,8 +570,9 @@ SHIFTSTART
 	|      |                      |       |                        |      |
 	|      |                      |       | When SHIFTMODE is set  |      |
 	|      |                      |       | to 1, this register    |      |
-	|      |                      |       | starts to output PWM0~3|      |
-	|      |                      |       | after writing 1.       |      |
+	|      |                      |       | starts to output       |      |
+	|      |                      |       | PWM[0]~[3] after       |      |
+	|      |                      |       | writing 1.             |      |
 	+------+----------------------+-------+------------------------+------+
 	| 31:1 | Reserved             |       |                        |      |
 	+------+----------------------+-------+------------------------+------+
@@ -577,7 +587,7 @@ PWM_OE
 	+------+----------------------+-------+------------------------+------+
 	| Bits | Name                 | Access| Description            | Reset|
 	+======+======================+=======+========================+======+
-	| 3:0  | PWM_OE               | R/W   | PWM0~3 IO output       | 0x0  |
+	| 3:0  | PWM_OE               | R/W   | PWM[0]~[3] IO output   | 0x0  |
 	|      |                      |       | enable                 |      |
 	|      |                      |       |                        |      |
 	|      |                      |       | 1 = IO is output,      |      |

--- a/SG200X/TRM/contents/en/peripherals/pwm.rst
+++ b/SG200X/TRM/contents/en/peripherals/pwm.rst
@@ -4,12 +4,22 @@ PWM
 Overview
 ~~~~~~~~
 
-The chip provides 1 set of 4 independent PWM signal outputs.
+The chip provides 4 PWM controllers PWM0, PWM1, PWM2 and PWM3.
+
+Each controller provides 4 independent PWM signal outputs. They are:
+
+- PWM0 includes PWM[0], PWM[1], PWM[2], PWM[3].
+
+- PWM1 includes PWM[4], PWM[5], PWM[6], PWM[7].
+
+- PWM2 includes PWM[8], PWM[9], PWM[10], PWM[11].
+
+- PWM3 includes PWM[12], PWM[13], PWM[14], PWM[15].
 
 Features
 ~~~~~~~~
 
-The PWM clock source can be selected from 100MHz or 148.5MHz, and the default is 100MHz. All 4 PWM channels can be operated independently:
+The PWM clock source can be selected from 100MHz or 148.5MHz, and the default is 100MHz.
 
 - There is an internal 30-bit counter, the output period and the number of high/low level beats are configurable.
 
@@ -22,15 +32,15 @@ The PWM clock source can be selected from 100MHz or 148.5MHz, and the default is
 Way of Working
 ~~~~~~~~~~~~~~
 
-The basic configuration process of PWM is as follows (taking PWM0 as an example):
+The basic configuration process of PWM is as follows (taking PWM[0] as an example):
 
 1. Based on the selected clock source, calculate the square wave period and low-level beat number to be output.
 
 2. Write the corresponding values to registers HLPERIOD0 and PERIOD0.
 
-3. To operate in continuous output mode, configure PWMMODE to 0, set PWMSTART[0] to 1, and PWM0 starts to output until PWMSTART[0] is set to 0 to end the output.
+3. To operate in continuous output mode, configure PWMMODE to 0, set PWMSTART[0] to 1, and PWM[0] starts to output until PWMSTART[0] is set to 0 to end the output.
 
-4. If you want to operate in the fixed pulse number output mode, configure PWMMODE as 1, and write the number of square waves to be output into the register PCOUNT0. After setting PWMSTART[0] to 1, PWM0 starts to output and ends automatically after reaching the set square wave number, and the status register PWMDONE changes from 0 to 1.
+4. If you want to operate in the fixed pulse number output mode, configure PWMMODE as 1, and write the number of square waves to be output into the register PCOUNT0. After setting PWMSTART[0] to 1, PWM[0] starts to output and ends automatically after reaching the set square wave number, and the status register PWMDONE changes from 0 to 1.
 
 .. _diagram_pwm_continuous_mode:
 .. figure:: ../../../../media/image133.png
@@ -48,7 +58,7 @@ For example: To output a waveform with a frequency of 1MHz, a low level ratio of
 
 1. Using the default 100MHz clock source, the period number (PERIOD0) is configured as 100MHz / 1MHz = 100, and the low level number (HLPERIOD0) is configured as 100 x 75% = 75. The number of pulses (PCOUNT0) is configured as 16.
 
-2. Write 1 to PWMSTART [0] to start outputting the waveform.
+2. Write 1 to PWMSTART[0] to start outputting the waveform.
 
 3. Read the register PWMDONE[0] until the value is 1, indicating that the output is completed.
 
@@ -83,11 +93,13 @@ Set SHIFTSTART to 0 to end the output, and read the register PWMDONE[3:0] until 
 PWM Register Overview
 ~~~~~~~~~~~~~~~~~~~~~
 
-An overview of the PWM registers is shown in table :ref:`table_pwm_register_overview`.
+An overview of the PWM registers is shown in table :ref:`table_pwm_register_overview`. Here take PWM0 controller as an example, the other 3 controllers are similar.
 
 .. include:: ../../contents-share/peripherals/pwm_registers_overview.table.rst
 
 PWM Register Description
 ~~~~~~~~~~~~~~~~~~~~~~~~
+
+Here take PWM0 controller as an example, the other 3 controllers are similar.
 
 .. include:: ../../contents-share/peripherals/pwn_registers_description.table.rst


### PR DESCRIPTION
The original document confused the concepts of controller and channel. This patchn corrected to: PWMn refers specifically to the controller, while PWM[n] refers specifically to the channel in the controller.

渲染后的 pdf 文档参考如下：

[sg2002_trm_cn.pdf](https://github.com/sophgo/sophgo-doc/files/15496296/sg2002_trm_cn.pdf)

[sg2002_trm_en.pdf](https://github.com/sophgo/sophgo-doc/files/15496298/sg2002_trm_en.pdf)
