### PR TITLE
SG2044: HowTo: modify SG2044 build info

### DIFF
--- a/SG2044/HowTo/How to Build SG2044 BSP.rst
+++ b/SG2044/HowTo/How to Build SG2044 BSP.rst
@@ -11,7 +11,7 @@ How to Build BSP
 
    .. code:: sh
 
-      $ sudo apt-get install autoconf automake autotools-dev curl python3 libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev libncurses-dev openssl libiberty-dev libssl-dev dkms libelf-dev libudev-dev libpci-dev golang-go qemu-user-static
+      $ sudo apt-get install autoconf automake autotools-dev curl python3 libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev libncurses-dev openssl libiberty-dev libssl-dev dkms libelf-dev libudev-dev libpci-dev golang-go qemu-user-static ninja-build uuid-dev gcc-riscv64-unknown-elf
 
 2. Build all from Source
 ========================
@@ -28,14 +28,12 @@ How to Build BSP
       $ git clone https://github.com/sophgo/sophgo-edk2.git
 
       # switch branch
-      $ cd zsbl
-      $ git checkout sg2260-pld
       $ cd ../opensbi
       $ git checkout sg2044-dev
       $ cd ../sophgo-edk2
       $ git checkout devel-sg2044
       $ cd ../linux-riscv
-      $ git checkout sg2044-dev-6.6
+      $ git checkout sg2044-dev-6.12
 
 - Build cross-compilation toolchains
 
@@ -76,10 +74,16 @@ How to Build BSP
       $ build_rv_zsbl
       $ build_rv_sbi
       $ build_rv_edk2
-      $ build_rv_kernel
+
+      # build Ubuntu
       $ build_rv_ubuntu_kernel
       $ build_rv_ubuntu_distro
       $ build_rv_ubuntu_image
+
+      # build openEuler
+      $ build_rv_euler_kernel
+      $ build_rv_euler_distro
+      $ build_rv_euler_image
 
 - The output files will be located in the ``install/soc_sg2044/single_chip`` directory.
 
@@ -89,9 +93,13 @@ How to Build BSP
 
       .
       ├── bsp-debs
-      │      ├── linux-headers-6.6.50.deb
-      │      ├── linux-image-6.6.50.deb
-      │      └── linux-libc-dev_6.6.50.deb
+      │      ├── linux-headers-6.12.deb
+      │      ├── linux-image-6.12.deb
+      │      └── linux-libc-dev_6.12.deb
+      ├── bsp-rpms
+      │      ├── kernel-6.12.riscv64.rpm
+      │      ├── kernel-devel-6.12.riscv64.rpm
+      │      └── kernel-headers-6.12.riscv64.rpm
       ├── firmware
       │      ├── fsbl.bin
       │      ├── fw_dynamic.bin
@@ -99,33 +107,43 @@ How to Build BSP
       │      ├── sg2044-evb.dtb
       │      ├── zsbl.bin
       │      └── SG2044.fd
-      └── ubuntu-sophgo.img
+      ├── openEuler-24.03-riscv64-sg2044.img
+      └── ubuntu-24.04.1-riscv64-sg2044.img
+
 
 
 3. Summary
 ==========
 
-+----------------+----------------------------------------------+------------------+------------------------+----------------------------+
-| Repository     | Link                                         | Branch           | Build Command          | Binary                     |
-+================+==============================================+==================+========================+============================+
-| zsbl           | https://github.com/sophgo/zsbl.git           | sg2260-pld       | build_rv_zsbl          | zsbl.bin                   |
-+----------------+----------------------------------------------+------------------+------------------------+----------------------------+
-| opensbi        | https://github.com/sophgo/opensbi.git        | sg2044-dev       | build_rv_sbi           | fw_dynamic.bin             |
-+----------------+----------------------------------------------+------------------+------------------------+----------------------------+
-| sophgo-edk2    | https://github.com/sophgo/sophgo-edk2.git    | devel-sg2044     |                        |                            |
-+----------------+----------------------------------------------+------------------+                        +                            +
-| edk2           | https://github.com/sophgo/edk2.git           | devel-sg2044     |                        |                            |
-+----------------+----------------------------------------------+------------------+                        +                            +
-| edk2-platforms | https://github.com/sophgo/edk2-platforms.git | devel-sg2044     | build_rv_edk2          | SG2044.fd                  |
-+----------------+----------------------------------------------+------------------+                        +                            +
-| edk2-non-osi   | https://github.com/sophgo/edk2-non-osi.git   | devel-sg2044     |                        |                            |
-+----------------+----------------------------------------------+------------------+------------------------+----------------------------+
-|                |                                              |                  |                        | linux-headers-6.6.50.deb   |
-+                +                                              +                  +                        +                            +
-| linux-riscv    | https://github.com/sophgo/linux-riscv.git    | sg2044-dev-6.6   | build_rv_ubuntu_kernel | linux-image-6.6.50.deb     |
-+                +                                              +                  +                        +                            +
-|                |                                              |                  |                        | linux-libc-dev_6.6.50.deb  |
-+                +                                              +                  +------------------------+----------------------------+
-|                |                                              |                  | build_rv_kernel        | sg2044-evb.dtb             |
-+----------------+----------------------------------------------+------------------+------------------------+----------------------------+
++----------------+----------------------------------------------+------------------+------------------------+----------------------------------+
+| Repository     | Link                                         | Branch           | Build Command          | Binary                           |
++================+==============================================+==================+========================+==================================+
+| zsbl           | https://github.com/sophgo/zsbl.git           | master           | build_rv_zsbl          | zsbl.bin                         |
++----------------+----------------------------------------------+------------------+------------------------+----------------------------------+
+| opensbi        | https://github.com/sophgo/opensbi.git        | sg2044-dev       | build_rv_sbi           | fw_dynamic.bin                   |
++----------------+----------------------------------------------+------------------+------------------------+----------------------------------+
+| sophgo-edk2    | https://github.com/sophgo/sophgo-edk2.git    | devel-sg2044     |                        |                                  |
++----------------+----------------------------------------------+------------------+                        +                                  +
+| edk2           | https://github.com/sophgo/edk2.git           | devel-sg2044     |                        |                                  |
++----------------+----------------------------------------------+------------------+                        +                                  +
+| edk2-platforms | https://github.com/sophgo/edk2-platforms.git | devel-sg2044     | build_rv_edk2          | SG2044.fd                        |
++----------------+----------------------------------------------+------------------+                        +                                  +
+| edk2-non-osi   | https://github.com/sophgo/edk2-non-osi.git   | devel-sg2044     |                        |                                  |
++----------------+----------------------------------------------+------------------+------------------------+----------------------------------+
+|                |                                              |                  |                        | linux-headers-6.12.deb           |
++                +                                              +                  +                        +                                  +
+| linux-riscv    | https://github.com/sophgo/linux-riscv.git    | sg2044-dev-6.12  | build_rv_ubuntu_kernel | linux-image-6.12.deb             |
++                +                                              +                  +                        +                                  +
+|                |                                              |                  |                        | linux-libc-dev_6.12.deb          |
++                +                                              +                  +                        +                                  +
+|                |                                              |                  |                        | sg2044-evb.dtb                   |
++                +                                              +                  +------------------------+----------------------------------+
+|                |                                              |                  | build_rv_euler_kernel  | kernel-6.12.riscv64.rpm          |
++                +                                              +                  +                        +                                  +
+|                |                                              |                  |                        | kernel-devel-6.12.riscv64.rpm    |
++                +                                              +                  +                        +                                  +
+|                |                                              |                  |                        | kernel-headers-6.12.riscv64.rpm  |
++                +                                              +                  +                        +                                  +
+|                |                                              |                  |                        | sg2044-evb.dtb                   |
++----------------+----------------------------------------------+------------------+------------------------+----------------------------------+
 

--- a/SG2044/HowTo/SG2044 Boot Flow.rst
+++ b/SG2044/HowTo/SG2044 Boot Flow.rst
@@ -20,7 +20,7 @@ SG2044's original firmware boot process:
 
 - **ZSBL (Zero-Stage BootLoader)**
 
-  Mainly load DTB, binaries of OpenSBI, and EDK II from microSD card or SPI Nor Flash into memory.
+  Mainly load configuration file (``conf.ini``), DTB, binaries of OpenSBI, and EDK II from microSD card or SPI Nor Flash into memory.
 
 - **OpenSBI (RISC-V Open Source Supervisor Binary Interface)**
 
@@ -38,7 +38,7 @@ SG2044's original firmware boot process:
 
 - **Linux**
 
-  Supported Linux distributions: Ubuntu 24.04.1, OpenEuler 24.03.
+  Supported Linux distributions: Ubuntu 24.04.1, openEuler 24.03.
 
-  Supported Linux Kernel Version: 6.6.50.
+  Supported Linux Kernel Version: 6.12.
 


### PR DESCRIPTION
 - Modify Linux kernel branch to 6.12.

 - Add openEuler build process.